### PR TITLE
Add support for viewing the Hijri date

### DIFF
--- a/custom_components/hijri_date/sensor.py
+++ b/custom_components/hijri_date/sensor.py
@@ -1,0 +1,18 @@
+from hijri_converter import convert
+from datetime import datetime
+
+# Get the current Gregorian date
+now = datetime.now()
+current_gregorian_date = convert.Gregorian(now.year, now.month, now.day)
+
+# Convert the current Gregorian date to Hijri
+current_hijri_date = current_gregorian_date.to_hijri()
+
+# Get the Hijri month name and day name
+hijri_month_name = current_hijri_date.month_name()
+hijri_day_of_week = current_hijri_date.weekday()
+hijri_day_names = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+hijri_day_name = hijri_day_names[hijri_day_of_week]
+
+# Print the result
+print(f'{hijri_day_name}, {current_hijri_date.day} {hijri_month_name} {current_hijri_date.year} AH')


### PR DESCRIPTION
I used to support viewing the Hijri date in Home Assistant using the Python script that converts the current Gregorian date to Hijri, and a command line sensor in the configuration.yaml that shows the Hijri date...along with automation that updates the date every day at midnight. It works properly for me, and I propose adding this support to the integration, along with updating the date each day. This should work locally (without the need for the Internet).
I also recommend that the prayer times calculation work without a cloud connection because the entities become unavailable when the Home Assistant disconnects from the integration cloud.